### PR TITLE
Fixes toggle()

### DIFF
--- a/lib/atom-shell-commands.js
+++ b/lib/atom-shell-commands.js
@@ -155,7 +155,12 @@
 	}
 	
 	function toggle() {
-		messageShow();
+		messageInit();
+		if (commands.panel && commands.panel.panel && commands.panel.panel.isVisible()) {
+			messageHide();
+		} else {
+			messageShow();
+		}
 	}
 	
 	function childStop() {


### PR DESCRIPTION
The current version of `toggle()` just shows the message-box, leaving the toggle command a bit broken.

(This change uses https://atom.io/docs/api/v1.0.0/Panel#instance-isVisible to figure out if the panel is currently visible.)
