### PR TITLE
"Silent" command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The `options` field is an key/value object contains:
 |---------|------|-------|
 | cwd | *[optional]* | Working directory of the command |
 | save | *[optional]* | True or false(default) to save the current file before execute |
+| silent | *[optional]* | True or false(default); true will not show the message panel (if it's closed) when this command is run. |
 | keymap | *[optional]* | A keymap string as defined by Atom. Pressing this key combination will trigger the target. Examples: ctrl-alt-k or cmd-U. |
 | env | *[optional]* | Key/value based system environment setting |
 

--- a/lib/atom-shell-commands.js
+++ b/lib/atom-shell-commands.js
@@ -338,7 +338,9 @@
 	function execute( command, args, options, matchs ) {
 		
 		messageClear();
-		messageShow();
+		if (!options.silent) {
+			messageShow();
+		}
 		quickfixReset();
 
 		var env = getEnv();

--- a/lib/atom-shell-commands.js
+++ b/lib/atom-shell-commands.js
@@ -155,7 +155,12 @@
 	}
 	
 	function toggle() {
-		messageShow();
+		messageInit();
+		if (commands.panel && commands.panel.panel && commands.panel.panel.isVisible()) {
+			messageHide();
+		} else {
+			messageShow();
+		}
 	}
 	
 	function childStop() {

--- a/lib/config.js
+++ b/lib/config.js
@@ -43,6 +43,10 @@
 								type: 'boolean',
 								default: false
 							},
+							silent: {
+								type: 'boolean',
+								default: false
+							},
 							keymap: {
 								type: 'string',
 								default: ''


### PR DESCRIPTION
I wrote this for my own needs (an on-stage demo that I'm triggering commands in the background for). If it's of any use to you, please feel free to use it.

This adds a `silent` boolean option for commands that defaults to `false`. When a command's `silent` option is `true`, running that command will not cause the message panel to open. (If the panel is already open, then it will stay shown, as normal.)

(This change includes #2.)
