### PR TITLE
Update with fixes for Windows and new features for a newer Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `command`, `arguments` and `options` values accepts the variables below:
 | {FileDir}        | Full path of current document without the file name |
 | {FileExt}        | File extension of current document |
 | {FileNameNoExt}  | File name of current document without path and extension |
-| {MainProjectDir} | Current project directory |
+| {ProjectDir} | Current project directory |
 | {ProjectRel}     | File name relativize to current project directory |
 | {CurRow}         | Current row(line number) where the cursor is located |
 | {CurCol}         | Current column index where the cursor is located |

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ This will create the atom command "atom-shell-commands:compile" that you can now
 
 | Field | Mode | Description |
 |-------|----|---------|
-| `name` | **[required]** | The name of the target. Viewed in the menu | 
-| `command` | **[required]** | The executable command |
+| `name` | **[required]** | The name of the target. Viewed in the menu |
+| `command` | **[required]** | The executable command (if not in terminal mode, can be a relative path to a file) |
 | `auguments` | *[optional]* | An array of arguments for the command |
 | `selector` | *[optional]* | atom selector, default is 'atom-workspace' |
 | `matchs` | *[optional]* | regular expression to match file name in output |
@@ -66,7 +66,7 @@ The `command`, `arguments` and `options` values accepts the variables below:
 | {FileDir}        | Full path of current document without the file name |
 | {FileExt}        | File extension of current document |
 | {FileNameNoExt}  | File name of current document without path and extension |
-| {ProjectDir}     | Current project directory |
+| {MainProjectDir} | Current project directory |
 | {ProjectRel}     | File name relativize to current project directory |
 | {CurRow}         | Current row(line number) where the cursor is located |
 | {CurCol}         | Current column index where the cursor is located |
@@ -87,6 +87,17 @@ The `options` field is an key/value object contains:
 | keymap | *[optional]* | A keymap string as defined by Atom. Pressing this key combination will trigger the target. Examples: ctrl-alt-k or cmd-U. |
 | env | *[optional]* | Key/value based system environment setting |
 | sound | *[optional]* | File path for a wav/mp3/ogg file which will be played to remind you that the job is finished |
+| context | *[optional]* | String of flags indicating which circumstances the command can be run under |
+
+The `options.context` field string can contain any of the following flags:
+
+| Flag | Description |
+|------|-------------|
+| `f` | Requires an open file to be focused by the user |
+| `e` | Requires an editor to be focused by the user |
+| `p` | Requires the focused editor to have a cursor |
+
+*If no flags are specified, the command can always be called.*
 
 Examples
 --------

--- a/lib/atom-shell-commands.js
+++ b/lib/atom-shell-commands.js
@@ -194,6 +194,8 @@
 				autoScroll: true,
 				maxHeight: "130px"
 			});
+      var children = commands.panel.element.children;
+      children[children.length - 1].classList.add('atom-shell-commands-console');
 		}
 	}
 	
@@ -264,7 +266,7 @@
     if(!commands.panel)
       messageInit();
     if(commands.panel.length > 0)
-      commands.panel[commands.panel.length - 1].text(message);
+      commands.panel.messages[commands.panel.messages.length - 1].text(message);
   }
 
 	function messageLine(file, line, column, message, style, preview) {
@@ -545,7 +547,7 @@
 
 		var stdout_cache = '';
 		var stderr_cache = '';
-    var newLine = 1;
+    var newLine = 0;
 
 		commands.childs[proc.pid] = proc;
 
@@ -555,7 +557,7 @@
 			while (true) {
 				var index = stdout_cache.indexOf('\n');
 				if (index < 0) {
-          outputTemporary(text, 'stdout', newLine == 0);
+          outputTemporary(stdout_cache, 'stdout', newLine == 0);
           newLine = 1;
           break;
         }
@@ -572,7 +574,7 @@
 			while (true) {
 				var index = stderr_cache.indexOf('\n');
 				if (index < 0) {
-          outputTemporary(text, 'stderr', newLine == 0);
+          outputTemporary(stderr_cache, 'stderr', newLine == 0);
           newLine = 2;
           break;
         }
@@ -583,21 +585,6 @@
 			}
 		} );
 
-		proc.stdout.on( 'close', function( code, signal ) {
-			// console.info('command closed', code, signal);
-			if (stdout_cache.length > 0) {
-				output(stdout_cache, 'stdout');
-				stdout_cache = '';
-			}
-		} );
-
-		proc.stderr.on( 'close', function( code, signal ) {
-			if (stderr_cache.length > 0) {
-				output(stderr_cache, 'stderr');
-				stderr_cache = '';
-			}
-		} );
-		
 		// Register code for error
 		proc.on('error', function(msg) {
 			output(msg, 'error');

--- a/lib/atom-shell-commands.js
+++ b/lib/atom-shell-commands.js
@@ -580,7 +580,7 @@
         FileExt: extname,
         FileNameNoExt: mainname,
         ProjectDirs: projdirs,
-        MainProjectDir: projdirs[0] || '',
+        ProjectDir: projdirs[0] || '',
         ProjectRel: relpath,
         CurRow: currow,
         CurCol: curcol,
@@ -605,7 +605,7 @@
 
       env = {
         ProjectDirs: projdirs,
-        MainProjectDir: projdirs[0] || '',
+        ProjectDir: projdirs[0] || '',
         CurRow: currow,
         CurCol: curcol,
         CurSelected: selected,
@@ -619,7 +619,7 @@
 
       env = {
         ProjectDirs: projdirs,
-        MainProjectDir: projdirs[0] || '',
+        ProjectDir: projdirs[0] || '',
         Context: '',
       };
       env.FilePath = env.FileName = env.FileDir = env.FileExt = env.FileNameNoExt = env.CurRow = env.CurCol = env.CurSelected = env.CurLineText = env.CurWord = ''; // Defaults to empty strings

--- a/lib/atom-shell-commands.js
+++ b/lib/atom-shell-commands.js
@@ -231,20 +231,53 @@
 			var position = commands.panel.body[0].scrollHeight;
 			commands.panel.add(text);
 			text.atompos = position - text.outerHeight();
+      lineCache = text;
 			return text;
 		}
 		return null;
 	}
-	
+
+  function messageReplace(message, style) {
+		if (!commands.panel) {
+			messageInit();
+		}
+		if (commands.panel) {
+			var text = new atommsgpanel.PlainMessageView({
+				raw: false,
+				message: message,
+				className: style
+			});
+			var position = commands.panel.body[0].scrollHeight;
+      commands.panel.messages[commands.panel.messages.length - 1].replaceWith(text);
+			commands.panel.messages[commands.panel.messages.length - 1] = text;
+
+      // Emulate the atom-message-panel code
+      if(commands.panel.messages.length === 0 && text.getSummary)
+        commands.panel.setSummary(text.getSummary());
+
+			text.atompos = position - text.outerHeight();
+      lineCache = text;
+			return text;
+		}
+		return null;
+  }
+
+  function messageReplaceText(message) {
+    if(!commands.panel)
+      messageInit();
+    if(commands.panel.length > 0)
+      commands.panel[commands.panel.length - 1].text(message);
+  }
+
 	function messageLine(file, line, column, message, style, preview) {
 		if (!commands.panel) {
 			messageInit();
 		}
 		if (commands.panel) {
 			var text = new atommsgpanel.LineMessageView({
-				file: file, 
+				file: file,
 				line: line,
-				column: column, 
+				column: column,
 				message: message,
 				className: style,
 				preview: preview
@@ -261,14 +294,47 @@
 		}
 		return null;
 	}
-	
+
+  function messageLineReplace(file, line, column, message, style, preview) {
+		if (!commands.panel) {
+			messageInit();
+		}
+		if (commands.panel) {
+			var text = new atommsgpanel.LineMessageView({
+				file: file,
+				line: line,
+				column: column,
+				message: message,
+				className: style,
+				preview: preview
+			});
+			text.position.text(message)
+			text.contents.text('');
+			text.position.addClass(style);
+			text.position.removeClass('text-subtle');
+			//text.position.removeClass('inline-block');
+			var position = commands.panel.body[0].scrollHeight;
+
+      commands.panel.messages[commands.panel.messages.length - 1].replaceWith(text);
+      commands.panel.messages[commands.panel.messages.length - 1] = text;
+
+      // Emulate the atom-message-panel code
+      if(commands.panel.messages.length === 0 && text.getSummary)
+        commands.panel.setSummary(text.getSummary());
+
+			text.atompos = position - text.outerHeight();
+			return text;
+		}
+		return null;
+  }
+
 	function updateScroll() {
 		messageInit();
 		if (commands.panel) {
 			commands.panel.updateScroll();
 		}
 	}
-	
+
 	function updateTitle(title) {
 		messageInit();
 		if (!commands.panel) return;
@@ -406,15 +472,22 @@
 		if (mode != 'terminal') {
 			messagePlain(echo, 'echo');
 		}
-		
+
 		var XRegExp = require('xregexp');
 		var path = require('path');
-		
+
 		for (var i = 0; i < matchs.length; i++) {
 			matchs[i] = XRegExp.XRegExp(matchs[i]);
 		}
-		
-		function output(text, style) {
+
+    function outputTemporary(text, style, newLine) {
+      if(newLine) {
+        messagePlain(text, style);
+        updateScroll();
+      } else
+        messageReplaceText(text);
+    }
+		function output(text, style, replacePreviousLine) {
 			for (var i = 0; i < matchs.length; i++) {
 				var result = XRegExp.XRegExp.exec(text, matchs[i]);
 				if (result == null) continue;
@@ -427,8 +500,15 @@
 				if (!path.isAbsolute(file)) {
 					file = path.join(cwd, file);
 				}
-				var text = messageLine(file, line, col, text, style);
-				updateScroll();
+
+        var text;
+        if(replacePreviousLine)
+          text = messageReplaceLine(file, line, col, text, style);
+				else {
+          text = messageLine(file, line, col, text, style);
+  				updateScroll();
+        }
+
 				if (text) {
 					var position = text.atompos;
 					if (position < 0) position = 0;
@@ -436,15 +516,19 @@
 				}
 				return;
 			}
-			messagePlain(text, style);
-			updateScroll();
+      if(replacePreviousLine)
+        messageReplace(text, style);
+      else {
+        messagePlain(text, style);
+        updateScroll();
+      }
 		}
-		
+
 		// sounds
 		var sounds = require('./sounds');
-		
+
 		// record time
-		var millisec = (new Date()).getTime();	
+		var millisec = (new Date()).getTime();
 		const spawn = require('child_process').spawn;
 		const terminal = require('./terminal');
 
@@ -463,7 +547,8 @@
 
 		var stdout_cache = '';
 		var stderr_cache = '';
-		
+    var newLine = 1;
+
 		commands.childs[proc.pid] = proc;
 
 		// Update console panel on data
@@ -471,10 +556,15 @@
 			stdout_cache += data;
 			while (true) {
 				var index = stdout_cache.indexOf('\n');
-				if (index < 0) break;
+				if (index < 0) {
+          outputTemporary(text, 'stdout', newLine == 0);
+          newLine = 1;
+          break;
+        }
 				var text = stdout_cache.substring(0, index + 1);
 				stdout_cache = stdout_cache.substring(index + 1);
-				output(text, 'stdout');
+				output(text, 'stdout', newLine == 1);
+        newLine = 0;
 			}
 		} );
 
@@ -483,10 +573,15 @@
 			stderr_cache += data;
 			while (true) {
 				var index = stderr_cache.indexOf('\n');
-				if (index < 0) break;
+				if (index < 0) {
+          outputTemporary(text, 'stderr', newLine == 0);
+          newLine = 2;
+          break;
+        }
 				var text = stderr_cache.substring(0, index + 1);
 				stderr_cache = stderr_cache.substring(index + 1);
-				output(text, 'stderr');
+				output(text, 'stderr', newLine == 2);
+        newLine = 0;
 			}
 		} );
 

--- a/lib/atom-shell-commands.js
+++ b/lib/atom-shell-commands.js
@@ -3,6 +3,7 @@
 
 	// Imports
 	var atomutils = require('atom');
+  var fs = require('fs');
 	var atommsgpanel = {
 		MessagePanelView: null,
 		PlainMessageView: null,
@@ -344,6 +345,8 @@
 		mode = (mode == 'window' || mode == 'open')? 'terminal' : mode;
 		mode = (mode != 'terminal' && mode != 'silent')? '' : mode;
 
+    var context = options.context || '';
+
 		if (mode != 'terminal') {
 			messageClear();
 			quickfixReset();
@@ -354,24 +357,30 @@
 		}
 
 		var env = getEnv();
-		if (env == null) {
-			env = {
-				FilePath: '',
-				FileName: '',
-				FileDir: '',
-				FileExt: '',
-				FileNameNoExt: '',
-				ProjectDir: '',
-				ProjectRel: ''				
-			}
-		}
-		
+
+    // Make sure we meet the required context
+    var flags = 'fep';
+    for(var i=0; i<flags.length; i++) {
+      if(context.indexOf(flags[i]) != -1 && env.Context.indexOf(flags[i]) == -1)
+        return;
+    }
+
 		var command = replace( command || '', env );
 		var args = replace( args || [], env );
 		var options = replace( options || {}, env );
 		var matchs = matchs || [];
 		var cwd = options.cwd || '';
-		
+
+    // If command is an executable in the project, run it
+    var chosendir = '';
+    for(var i=0; i<env.ProjectDirs.length; i++) {
+      try {
+        fs.accessSync(env.ProjectDirs[i] + '\\' + command, fs.F_OK);
+        chosendir = env.ProjectDirs[i] + '\\';
+        break;
+      } catch(e) {}
+    }
+
 		if (options.save == true) {
 			var editor = atom.workspace.getActiveTextEditor();
 			if (editor) {
@@ -444,10 +453,14 @@
 			//messagePlain("open new terminal to launch", "echo");
 			return;
 		}
-		
-		// Run the spawn, we pass argv to make a shallow copy of the array because spawn will modify it.
-		var proc = spawn( command, argv, options );
-		
+
+    // Remove quotes around filenames, as they will screw up the command
+    if(command[0] == '"' && command[command.length - 1] == '"')
+      command = command.substr(1, command.length - 2);
+
+      // Run the spawn, we pass argv to make a shallow copy of the array because spawn will modify it.
+		var proc = spawn( chosendir + command, argv, options );
+
 		var stdout_cache = '';
 		var stderr_cache = '';
 		
@@ -525,55 +538,93 @@
 
 	// Generate Environment variables
 	function getEnv() {
+    var path, filepath, filename, filedir, info, extname, mainname, projdirs, relpath, selected, position, curcol, currow, linetext, curword, env, isFile = true, isEditor = true;
+
 		var editor = atom.workspace.getActiveTextEditor();
 		if (editor == undefined || editor == null)
-			return null;
-		if (editor.getPath == undefined || editor.getPath == null)
-			return null;
-			
-		var filepath = editor.getPath();
+			isFile = isEditor = false;
+		else if ('getPath' in editor && typeof(editor.getPath) == 'function')
+      filepath = editor.getPath();
 
-		if (filepath == undefined || filepath == null) {
-			return null;
-		}
-		
-		var path = require('path');
-		var filename = path.basename(filepath);
-		var filedir = path.dirname(filepath);
-		
-		var info = path.parse(filepath);
-		var extname = info.ext;
-		var mainname = info.name;
-		var paths = atom.project.relativizePath(filepath);
-		if (extname == undefined || extname == null) extname = "";	
-		var selected = editor.getSelectedText() || "";
-		var position = editor.getCursorBufferPosition() || null;
-		var curcol = (position)? position.column : 0;
-		var currow = (position)? position.row : 0;
-		var linetext = "";
-		var curword = "";
+		if (!filepath)
+      isFile = false;
 
-		if (position) {
-			var range = [[currow, 0], [currow, 1E10]];
-			linetext = editor.getTextInBufferRange(range) || '';
-			curword = editor.getWordUnderCursor();
-		}
+    if(isFile) {
+      path = require('path');
+      filename = path.basename(filepath);
+      filedir = path.dirname(filepath);
 
-		var env = {
-			FilePath: filepath,
-			FileName: filename,
-			FileDir: filedir,
-			FileExt: extname,
-			FileNameNoExt: mainname,
-			ProjectDir: (paths[0])? paths[0] : "",
-			ProjectRel: paths[1],
-			CurRow: currow,
-			CurCol: curcol,
-			CurSelected: selected,
-			CurLineText: linetext,
-			CurWord: curword
-		};
-		
+      info = path.parse(filepath);
+      extname = info.ext;
+      mainname = info.name;
+      relpath = atom.project.relativizePath(filepath)[0];
+      projdirs = atom.project.getPaths();
+      if (extname == undefined || extname == null) extname = "";
+      selected = editor.getSelectedText() || "";
+      position = editor.getCursorBufferPosition() || null;
+      curcol = (position)? position.column : 0;
+      currow = (position)? position.row : 0;
+      linetext = "";
+      curword = "";
+
+      if (position) {
+        var range = [[currow, 0], [currow, 1E10]];
+        linetext = editor.getTextInBufferRange(range) || '';
+        curword = editor.getWordUnderCursor();
+      }
+
+      env = {
+        FilePath: filepath,
+        FileName: filename,
+        FileDir: filedir,
+        FileExt: extname,
+        FileNameNoExt: mainname,
+        ProjectDirs: projdirs,
+        MainProjectDir: projdirs[0] || '',
+        ProjectRel: relpath,
+        CurRow: currow,
+        CurCol: curcol,
+        CurSelected: selected,
+        CurLineText: linetext,
+        CurWord: curword,
+        Context: 'fe' + (position ? 'p' : ''),
+      };
+    } else if(isEditor) {
+      projdirs = atom.project.getPaths();
+      selected = editor.getSelectedText() || "";
+      position = editor.getCursorBufferPosition() || null;
+      curcol = (position)? position.column : 0;
+      currow = (position)? position.row : 0;
+      linetext = "";
+      curword = "";
+
+      if(position) {
+        linetext = editor.lineTextForBufferRow(currow);
+        curword = editor.getWordUnderCursor();
+      }
+
+      env = {
+        ProjectDirs: projdirs,
+        MainProjectDir: projdirs[0] || '',
+        CurRow: currow,
+        CurCol: curcol,
+        CurSelected: selected,
+        CurLineText: linetext,
+        CurWord: curword,
+        Context: 'e' + (position ? 'p' : ''),
+      }
+      env.FilePath = env.FileName = env.FileDir = env.FileExt = env.FileNameNoExt = ''; // Defaults to empty strings
+    } else {
+      projdirs = atom.project.getPaths();
+
+      env = {
+        ProjectDirs: projdirs,
+        MainProjectDir: projdirs[0] || '',
+        Context: '',
+      };
+      env.FilePath = env.FileName = env.FileDir = env.FileExt = env.FileNameNoExt = env.CurRow = env.CurCol = env.CurSelected = env.CurLineText = env.CurWord = ''; // Defaults to empty strings
+    }
+
 		return env;
 	}
 
@@ -597,9 +648,8 @@
 	function replaceString( input, vars ) {
 		var keys = Object.keys(vars);
 		keys.forEach( function(key) {
-			var word = '{' + key + '}';
-			var value = vars[key];
-			input = input.split(word).join(value);
+      if(key != 'ProjectDirs' && key != 'Context')
+        input = input.replace('{' + key + '}', vars[key]);
 		});
 		return input;
 	}

--- a/lib/atom-shell-commands.js
+++ b/lib/atom-shell-commands.js
@@ -231,7 +231,6 @@
 			var position = commands.panel.body[0].scrollHeight;
 			commands.panel.add(text);
 			text.atompos = position - text.outerHeight();
-      lineCache = text;
 			return text;
 		}
 		return null;
@@ -256,7 +255,6 @@
         commands.panel.setSummary(text.getSummary());
 
 			text.atompos = position - text.outerHeight();
-      lineCache = text;
 			return text;
 		}
 		return null;

--- a/lib/config.js
+++ b/lib/config.js
@@ -58,7 +58,11 @@
 							sound: {
 								type: 'string',
 								default: ''
-							}
+							},
+              context: {
+                type: 'string',
+                default: 'p'
+              }
 						},
 						default : {}
 					},

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -61,13 +61,13 @@
 
 	module.exports.open_windows = function(command, argv, options) {
 		var argument = ['/C', 'start', cmd, '/C'];
-		argument.push(path.join(vendor, "launch.cmd"));
-		argument.push(command);
+		argument.push('@echo off ^& ' + command.replace(/[\^&<>]/g, '^$&') + ' ^& pause');
 		argument = argument.concat(argv);
 		options.detached = true;
 		options.stdout = 'ignore';
 		options.stderr = 'ignore';
 		options.shell = false;
+    options.windowsVerbatimArguments = true;
 		command = cmd;
 		if (false) {
 			command = 'cmd.exe';

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "extensions": {
       ".js": [
         "lib/atom-shell-commands.js",
-        "lib/config.js",
         "node_modules/win-spawn/index.js"
       ],
       ".json": [

--- a/styles/atom-shell-commands.less
+++ b/styles/atom-shell-commands.less
@@ -14,50 +14,50 @@
 	max-height: 24em;
 	min-height: 5em;
 	overflow-y: scroll;
-}
 
-.hide {
-	display: none;
-}
+  .hide {
+  	display: none;
+  }
 
-.stdout {
-	color: @text-color;
-	white-space: pre;
-}
+  .stdout {
+  	color: @text-color;
+  	white-space: pre;
+  }
 
-.stdout-match {
-	color: @text-color-warning;
-	white-space: pre;
-}
+  .stdout-match {
+  	color: @text-color-warning;
+  	white-space: pre;
+  }
 
-.stdout-match:hover {
-	text-decoration: underline;
-}
+  .stdout-match:hover {
+  	text-decoration: underline;
+  }
 
-.stderr {
-	color: @text-color;
-	white-space: pre;
-}
+  .stderr {
+  	color: @text-color;
+  	white-space: pre;
+  }
 
-.stderr-match {
-	color: @text-color-warning;
-	white-space: pre;
-}
+  .stderr-match {
+  	color: @text-color-warning;
+  	white-space: pre;
+  }
 
-.stderr-match:hover {
-	text-decoration: underline;
-}
+  .stderr-match:hover {
+  	text-decoration: underline;
+  }
 
-.selected {
-	background-color: @background-color-highlight;
-}
+  .selected {
+  	background-color: @background-color-highlight;
+  }
 
-.echo {
-	color: @text-color-subtle;
-	white-space: pre;
-}
+  .echo {
+  	color: @text-color-subtle;
+  	white-space: pre;
+  }
 
-.error {
-	color: @text-color-error;
-	white-space: pre;
+  .error {
+  	color: @text-color-error;
+  	white-space: pre;
+  }
 }

--- a/vendor/launch.cmd
+++ b/vendor/launch.cmd
@@ -1,4 +1,0 @@
-@echo off
-%*
-pause
-


### PR DESCRIPTION
- Removed the `launch.cmd` requirement, instead putting everything into one command (makes it much simpler)
- If not in terminal mode and a filename command has quotes around it, remove those quotes (necessary in terminal mode, was breaking otherwise in normal mode)
- If not in terminal mode, allow command to be relative path to an executable in any project directory, or an absolute path
- Make `ProjectDir` always point to the main project directory, as it would be an empty string if no file was opened
- Add ability for commands to be run only in certain contexts, using a set of flags
- Use whatever data is available in the current 'context', instead of refusing to run the command if no file or editor is open
