### PR TITLE
Adding support for save all

### DIFF
--- a/lib/atom-shell-commands.js
+++ b/lib/atom-shell-commands.js
@@ -22,7 +22,7 @@
 	}
 
 	commands.activate = function( state ) {
-		
+
 		// Define and update a command list from the user config
 		var registeredAtomCommands = [];
 
@@ -40,7 +40,7 @@
 
 			registeredAtomCommands = [];
 
-			if (value != null && value != undefined && 
+			if (value != null && value != undefined &&
 				value.commands != null && value.commands != undefined) {
 				// Register new commands
 				value.commands.forEach( function( command ) {
@@ -65,61 +65,61 @@
 							]
 						} ]
 					} ] );
-					
+
 					// Register it in the subscriptions;
 					registeredAtomCommands.push( atomCommand );
 					registeredAtomCommands.push( menuEntry );
 
 					commands.subscriptions.add( atomCommand );
 					commands.subscriptions.add( menuEntry );
-					
+
 					var options = command.options || {};
 					var keymap = options.keymap || '';
-					
+
 					if (keymap) {
 						const specifies = { 'atom-workspace': {} };
 						specifies['atom-workspace'][keymap] = commandName;
 						var keyname = 'atom-shell-commands-keymap:' + command.name;
 						var entry = atom.keymaps.add(keyname, specifies);
-						
+
 						registeredAtomCommands.push(entry);
 						commands.subscriptions.add(entry);
 					}
 				} );
 			}
-			
+
 		} );
-		
+
 		var where = 'atom-workspace';
 		var prefix = 'atom-shell-commands-config:';
 		var subscriptions = commands.subscriptions;
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'toggle', function() {
 			toggle();
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'stop', function() {
 			childStop();
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'kill', function() {
 			childKill();
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'error-first', function() {
 			quickfixActive(0);
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'error-last', function() {
 			quickfixActive(commands.quickfix.error.length - 1);
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'error-next', function() {
 			if (commands.quickfix.index < commands.quickfix.error.length - 1) {
 				quickfixActive(commands.quickfix.index + 1);
 			}
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'error-prev', function() {
 			if (commands.quickfix.index > 0) {
 				quickfixActive(commands.quickfix.index - 1);
@@ -136,14 +136,14 @@
 				child.kill('SIGKILL');
 			});
 		}
-		
+
 		commands.subscriptions.dispose();
-		
+
 		if (commands.panel) {
 			commands.panel.remove();
 			commands.panel = null;
 		}
-		
+
 		if (commands.quickfix) {
 			commands.quickfix.error = [];
 			commands.quickfix.index = -1;
@@ -153,7 +153,7 @@
 	commands.serialize = function() {
 		return {};
 	}
-	
+
 	function toggle() {
 		messageInit();
 		if (commands.panel && commands.panel.panel && commands.panel.panel.isVisible()) {
@@ -162,7 +162,7 @@
 			messageShow();
 		}
 	}
-	
+
 	function childStop() {
 		var pids = Object.keys(commands.childs);
 		pids.forEach(function(pid) {
@@ -170,7 +170,7 @@
 			child.kill();
 		});
 	}
-	
+
 	function childKill() {
 		var pids = Object.keys(commands.childs);
 		pids.forEach(function(pid) {
@@ -179,14 +179,14 @@
 			delete commands.childs[pid];
 		});
 	}
-	
+
 	function messageInit() {
 		if (!commands.panel) {
 			var module = require ('atom-message-panel');
 			atommsgpanel.MessagePanelView = module.MessagePanelView;
 			atommsgpanel.LineMessageView = module.LineMessageView;
 			atommsgpanel.PlainMessageView = module.PlainMessageView;
-			
+
 			commands.panel = new atommsgpanel.MessagePanelView({
 				title: 'Atom Shell Commands',
 				rawTitle: false,
@@ -195,28 +195,28 @@
 			});
 		}
 	}
-	
+
 	function messageShow() {
 		messageInit();
 		if (commands.panel) {
 			commands.panel.attach();
 		}
 	}
-	
+
 	function messageHide() {
 		messageInit();
 		if (commands.panel) {
 			commands.panel.close();
 		}
 	}
-	
+
 	function messageClear() {
 		messageInit();
 		if (commands.panel) {
 			commands.panel.clear();
 		}
 	}
-	
+
 	function messagePlain(message, style) {
 		if (!commands.panel) {
 			messageInit();
@@ -234,16 +234,16 @@
 		}
 		return null;
 	}
-	
+
 	function messageLine(file, line, column, message, style, preview) {
 		if (!commands.panel) {
 			messageInit();
 		}
 		if (commands.panel) {
 			var text = new atommsgpanel.LineMessageView({
-				file: file, 
+				file: file,
 				line: line,
-				column: column, 
+				column: column,
 				message: message,
 				className: style,
 				preview: preview
@@ -260,14 +260,14 @@
 		}
 		return null;
 	}
-	
+
 	function updateScroll() {
 		messageInit();
 		if (commands.panel) {
 			commands.panel.updateScroll();
 		}
 	}
-	
+
 	function updateTitle(title) {
 		messageInit();
 		if (!commands.panel) return;
@@ -277,7 +277,7 @@
 			commands.panel.setTitle('Atom Shell Commands: ' + title);
 		}
 	}
-	
+
 	function quickfixReset() {
 		if (commands.quickfix) {
 			var quickfix = commands.quickfix;
@@ -294,7 +294,7 @@
 			quickfix.error = [];
 		}
 	}
-	
+
 	function quickfixPush(view, filename, line, column, position, style) {
 		var obj = {
 			view: view,
@@ -308,7 +308,7 @@
 			commands.quickfix.error.push(obj);
 		}
 	}
-	
+
 	function quickfixActive(index) {
 		if (commands.panel == null) return -1;
 		if (commands.panel.body == null) return -2;
@@ -330,14 +330,14 @@
 		quickfix.index = index;
 		if (error.view) {
 			error.view.goToLine();
-		}	
+		}
 		return 0;
 	}
-	
+
 	// Execute an OS command
 	function execute( command, args, options, matchs ) {
 		if (options == null || options == undefined) options = {};
-		
+
 		var mode = options.mode || '';
 
 		mode = (mode == '' && options.silent)? 'silent' : mode;
@@ -362,16 +362,23 @@
 				FileExt: '',
 				FileNameNoExt: '',
 				ProjectDir: '',
-				ProjectRel: ''				
+				ProjectRel: ''
 			}
 		}
-		
+
 		var command = replace( command || '', env );
 		var args = replace( args || [], env );
 		var options = replace( options || {}, env );
 		var matchs = matchs || [];
 		var cwd = options.cwd || '';
-		
+
+		if (options.saveall == true) {
+			var editors = atom.workspace.getTextEditors();
+			editors.forEach(function(editor) {
+				editor.save();
+			})
+		}
+
 		if (options.save == true) {
 			var editor = atom.workspace.getActiveTextEditor();
 			if (editor) {
@@ -382,7 +389,7 @@
 				}
 			}
 		}
-		
+
 		// make a copy of args to avoid modify config
 		var argv = []
 		for (var i = 0; i < args.length; i++) {
@@ -397,14 +404,14 @@
 		if (mode != 'terminal') {
 			messagePlain(echo, 'echo');
 		}
-		
+
 		var XRegExp = require('xregexp');
 		var path = require('path');
-		
+
 		for (var i = 0; i < matchs.length; i++) {
 			matchs[i] = XRegExp.XRegExp(matchs[i]);
 		}
-		
+
 		function output(text, style) {
 			for (var i = 0; i < matchs.length; i++) {
 				var result = XRegExp.XRegExp.exec(text, matchs[i]);
@@ -430,12 +437,12 @@
 			messagePlain(text, style);
 			updateScroll();
 		}
-		
+
 		// sounds
 		var sounds = require('./sounds');
-		
+
 		// record time
-		var millisec = (new Date()).getTime();	
+		var millisec = (new Date()).getTime();
 		const spawn = require('child_process').spawn;
 		const terminal = require('./terminal');
 
@@ -444,13 +451,13 @@
 			//messagePlain("open new terminal to launch", "echo");
 			return;
 		}
-		
+
 		// Run the spawn, we pass argv to make a shallow copy of the array because spawn will modify it.
 		var proc = spawn( command, argv, options );
-		
+
 		var stdout_cache = '';
 		var stderr_cache = '';
-		
+
 		commands.childs[proc.pid] = proc;
 
 		// Update console panel on data
@@ -491,19 +498,19 @@
 				stderr_cache = '';
 			}
 		} );
-		
+
 		// Register code for error
 		proc.on('error', function(msg) {
 			output(msg, 'error');
 		});
-		
+
 		// Register code for termination
 		proc.on('close', function(code) {
 			var current = (new Date()).getTime();
 			var delta = (current - millisec) * 0.001;
 			var style = 'echo';
 			if (code == null || code == undefined) {
-				output('[Finished in ' + delta.toFixed(2) + ' seconds]', style);				
+				output('[Finished in ' + delta.toFixed(2) + ' seconds]', style);
 			}	else {
 				if (code == 0) {
 					output('[Finished in ' + delta.toFixed(2) + ' seconds]', style);
@@ -511,11 +518,11 @@
 					output('[Finished in ' + delta.toFixed(2) + ' seconds, with code ' + code.toString() + ']', style);
 				}
 			}
-			
+
 			if (proc.pid in commands.childs) {
 				delete commands.childs[proc.pid];
-			}			
-			
+			}
+
 			if (options.sound != undefined && options.sound != null && options.sound != '') {
 				sounds.play(options.sound);
 			}
@@ -530,22 +537,22 @@
 			return null;
 		if (editor.getPath == undefined || editor.getPath == null)
 			return null;
-			
+
 		var filepath = editor.getPath();
 
 		if (filepath == undefined || filepath == null) {
 			return null;
 		}
-		
+
 		var path = require('path');
 		var filename = path.basename(filepath);
 		var filedir = path.dirname(filepath);
-		
+
 		var info = path.parse(filepath);
 		var extname = info.ext;
 		var mainname = info.name;
 		var paths = atom.project.relativizePath(filepath);
-		if (extname == undefined || extname == null) extname = "";	
+		if (extname == undefined || extname == null) extname = "";
 		var selected = editor.getSelectedText() || "";
 		var position = editor.getCursorBufferPosition() || null;
 		var curcol = (position)? position.column : 0;
@@ -573,7 +580,7 @@
 			CurLineText: linetext,
 			CurWord: curword
 		};
-		
+
 		return env;
 	}
 
@@ -606,7 +613,7 @@
 
 	// Replace array string elements with variables
 	function replaceArray( input, vars ) {
-		var output = new Array(input.length);	
+		var output = new Array(input.length);
 		for ( var i = 0; i < input.length; i++ ) {
 			output[ i ] = replace( input[ i ], vars );
 		}
@@ -629,5 +636,3 @@
 	module.exports = commands;
 
 } )( window, atom, require, module );
-
-

--- a/lib/config.js
+++ b/lib/config.js
@@ -43,6 +43,10 @@
 								type: 'boolean',
 								default: false
 							},
+							saveall: {
+								type: 'boolean',
+								default: false
+							},
 							silent: {
 								type: 'boolean',
 								default: false


### PR DESCRIPTION
I found this plugin useful, I just wanted something simple to run make with a single key. The only issue was it would only save the current file so I added support to save all open files in case there edits across files