### PR TITLE
Renamed commands -> commandsList as commands is reserved on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # atom-shell-commands package
 
-Customize shell commands for atom. Similar to 'Run Commands' in NotePad++, 'User Tool' in EditPlus/UltraEdit, 'External Tool' in GEdit and 'Shell Commands' in TextMate. 
+Customize shell commands for atom. Similar to 'Run Commands' in NotePad++, 'User Tool' in EditPlus/UltraEdit, 'External Tool' in GEdit and 'Shell Commands' in TextMate.
 
 Preface
 -------
@@ -17,9 +17,9 @@ Feature
 - Keymap config allow you to make shortcut to each command.
 - Shell output (stdout/stderr) can be captured in the bottom panel.
 - Click the filename in the output panel will open it.
-- Regular expression to match filename and line number in the error output. 
+- Regular expression to match filename and line number in the error output.
 - Hotkeys to navigate errors one by one just like quickfix in vim.
-- Fast and lightweight, loading time is less than 2 milliseconds (TimeCop). 
+- Fast and lightweight, loading time is less than 2 milliseconds (TimeCop).
 
 Installation
 ------------
@@ -31,7 +31,7 @@ Setup
 Configure commands on your config file (File->Open Your Config, or ~/.atom/config.cson) like this, add 'atom-shell-commands' in your user config file:
 ```cson
   "atom-shell-commands":
-    commands: [
+    commandsList: [
       {
         name: "compile"
         command: "d:/dev/mingw/bin/gcc"
@@ -50,7 +50,7 @@ This will create the atom command "atom-shell-commands:compile" that you can now
 
 | Field | Mode | Description |
 |-------|----|---------|
-| `name` | **[required]** | The name of the target. Viewed in the menu | 
+| `name` | **[required]** | The name of the target. Viewed in the menu |
 | `command` | **[required]** | The executable command |
 | `auguments` | *[optional]* | An array of arguments for the command |
 | `selector` | *[optional]* | atom selector, default is 'atom-workspace' |
@@ -184,7 +184,7 @@ Example user config file which is using error matching:
 ```cson
 *:
   "atom-shell-commands":
-    commands: [
+    commandsList: [
       {
         name: "compile"
         command: "d:/dev/mingw/bin/gcc"
@@ -220,7 +220,7 @@ Atom-shell-commands has a special design in the output panel to speedup the edit
 | atom-shell-commands-config:error-next | go to the next error |
 | atom-shell-commands-config:error-prev | go to the previous error |
 
-To avoid hotkey conflict to other packages, Atom-shell-commands has none predefined keymap, just leave the it to user. You can trigger them from `Atom Shell Commands` menu under `Packages`, or from command palette directly. 
+To avoid hotkey conflict to other packages, Atom-shell-commands has none predefined keymap, just leave the it to user. You can trigger them from `Atom Shell Commands` menu under `Packages`, or from command palette directly.
 
 The most efficient way is binding to your keymap config by simply adding few lines in ~/.atom/keymap.cson （or open it in the `File` menu):
 ```cson
@@ -229,11 +229,11 @@ The most efficient way is binding to your keymap config by simply adding few lin
     'F10': 'atom-shell-commands-config:error-prev'
 ```
 
-Now you can have your F9/F10 to navigate errors without leaving your hand from keyboard to mouse/touch pad. 
+Now you can have your F9/F10 to navigate errors without leaving your hand from keyboard to mouse/touch pad.
 
 Misc
 ----
-atom-shell-commands has been tested in windows, mac os and ubuntu. You can use 'open' in mac os or '/usr/bin/gnome-terminal' in ubuntu to open a new window and execute your command. 
+atom-shell-commands has been tested in windows, mac os and ubuntu. You can use 'open' in mac os or '/usr/bin/gnome-terminal' in ubuntu to open a new window and execute your command.
 
 As executing program in a new terminal window correctly is a little tricky thing, I create a script to let you open a new terminal window to execute your program in both Windows, Linux (ubuntu), Cygwin and Mac OS X, you can try it from: https://github.com/skywind3000/terminal.
 
@@ -250,6 +250,3 @@ Reference
 - [https://github.com/joefitzgerald/go-plus](https://github.com/joefitzgerald/go-plus) (referenced).
 - [https://github.com/noseglid/atom-build](https://github.com/noseglid/atom-build) (referenced).
 - [https://github.com/ksxatompackages/cmd-exec](https://github.com/ksxatompackages/cmd-exec) (referenced).
-
-
-

--- a/lib/atom-shell-commands.js
+++ b/lib/atom-shell-commands.js
@@ -22,7 +22,7 @@
 	}
 
 	commands.activate = function( state ) {
-		
+
 		// Define and update a command list from the user config
 		var registeredAtomCommands = [];
 
@@ -40,10 +40,10 @@
 
 			registeredAtomCommands = [];
 
-			if (value != null && value != undefined && 
-				value.commands != null && value.commands != undefined) {
+			if (value != null && value != undefined &&
+				value.commandsList != null && value.commandsList != undefined) {
 				// Register new commands
-				value.commands.forEach( function( command ) {
+				value.commandsList.forEach( function( command ) {
 
 					// Create an atom command for each entry
 					var commandName = 'atom-shell-commands:' + command.name;
@@ -65,61 +65,61 @@
 							]
 						} ]
 					} ] );
-					
+
 					// Register it in the subscriptions;
 					registeredAtomCommands.push( atomCommand );
 					registeredAtomCommands.push( menuEntry );
 
 					commands.subscriptions.add( atomCommand );
 					commands.subscriptions.add( menuEntry );
-					
+
 					var options = command.options || {};
 					var keymap = options.keymap || '';
-					
+
 					if (keymap) {
 						const specifies = { 'atom-workspace': {} };
 						specifies['atom-workspace'][keymap] = commandName;
 						var keyname = 'atom-shell-commands-keymap:' + command.name;
 						var entry = atom.keymaps.add(keyname, specifies);
-						
+
 						registeredAtomCommands.push(entry);
 						commands.subscriptions.add(entry);
 					}
 				} );
 			}
-			
+
 		} );
-		
+
 		var where = 'atom-workspace';
 		var prefix = 'atom-shell-commands-config:';
 		var subscriptions = commands.subscriptions;
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'toggle', function() {
 			toggle();
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'stop', function() {
 			childStop();
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'kill', function() {
 			childKill();
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'error-first', function() {
 			quickfixActive(0);
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'error-last', function() {
 			quickfixActive(commands.quickfix.error.length - 1);
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'error-next', function() {
 			if (commands.quickfix.index < commands.quickfix.error.length - 1) {
 				quickfixActive(commands.quickfix.index + 1);
 			}
 		}));
-		
+
 		subscriptions.add(atom.commands.add(where, prefix + 'error-prev', function() {
 			if (commands.quickfix.index > 0) {
 				quickfixActive(commands.quickfix.index - 1);
@@ -136,14 +136,14 @@
 				child.kill('SIGKILL');
 			});
 		}
-		
+
 		commands.subscriptions.dispose();
-		
+
 		if (commands.panel) {
 			commands.panel.remove();
 			commands.panel = null;
 		}
-		
+
 		if (commands.quickfix) {
 			commands.quickfix.error = [];
 			commands.quickfix.index = -1;
@@ -153,7 +153,7 @@
 	commands.serialize = function() {
 		return {};
 	}
-	
+
 	function toggle() {
 		messageInit();
 		if (commands.panel && commands.panel.panel && commands.panel.panel.isVisible()) {
@@ -162,7 +162,7 @@
 			messageShow();
 		}
 	}
-	
+
 	function childStop() {
 		var pids = Object.keys(commands.childs);
 		pids.forEach(function(pid) {
@@ -170,7 +170,7 @@
 			child.kill();
 		});
 	}
-	
+
 	function childKill() {
 		var pids = Object.keys(commands.childs);
 		pids.forEach(function(pid) {
@@ -179,14 +179,14 @@
 			delete commands.childs[pid];
 		});
 	}
-	
+
 	function messageInit() {
 		if (!commands.panel) {
 			var module = require ('atom-message-panel');
 			atommsgpanel.MessagePanelView = module.MessagePanelView;
 			atommsgpanel.LineMessageView = module.LineMessageView;
 			atommsgpanel.PlainMessageView = module.PlainMessageView;
-			
+
 			commands.panel = new atommsgpanel.MessagePanelView({
 				title: 'Atom Shell Commands',
 				rawTitle: false,
@@ -195,28 +195,28 @@
 			});
 		}
 	}
-	
+
 	function messageShow() {
 		messageInit();
 		if (commands.panel) {
 			commands.panel.attach();
 		}
 	}
-	
+
 	function messageHide() {
 		messageInit();
 		if (commands.panel) {
 			commands.panel.close();
 		}
 	}
-	
+
 	function messageClear() {
 		messageInit();
 		if (commands.panel) {
 			commands.panel.clear();
 		}
 	}
-	
+
 	function messagePlain(message, style) {
 		if (!commands.panel) {
 			messageInit();
@@ -234,16 +234,16 @@
 		}
 		return null;
 	}
-	
+
 	function messageLine(file, line, column, message, style, preview) {
 		if (!commands.panel) {
 			messageInit();
 		}
 		if (commands.panel) {
 			var text = new atommsgpanel.LineMessageView({
-				file: file, 
+				file: file,
 				line: line,
-				column: column, 
+				column: column,
 				message: message,
 				className: style,
 				preview: preview
@@ -260,14 +260,14 @@
 		}
 		return null;
 	}
-	
+
 	function updateScroll() {
 		messageInit();
 		if (commands.panel) {
 			commands.panel.updateScroll();
 		}
 	}
-	
+
 	function updateTitle(title) {
 		messageInit();
 		if (!commands.panel) return;
@@ -277,7 +277,7 @@
 			commands.panel.setTitle('Atom Shell Commands: ' + title);
 		}
 	}
-	
+
 	function quickfixReset() {
 		if (commands.quickfix) {
 			var quickfix = commands.quickfix;
@@ -294,7 +294,7 @@
 			quickfix.error = [];
 		}
 	}
-	
+
 	function quickfixPush(view, filename, line, column, position, style) {
 		var obj = {
 			view: view,
@@ -308,7 +308,7 @@
 			commands.quickfix.error.push(obj);
 		}
 	}
-	
+
 	function quickfixActive(index) {
 		if (commands.panel == null) return -1;
 		if (commands.panel.body == null) return -2;
@@ -330,14 +330,14 @@
 		quickfix.index = index;
 		if (error.view) {
 			error.view.goToLine();
-		}	
+		}
 		return 0;
 	}
-	
+
 	// Execute an OS command
 	function execute( command, args, options, matchs ) {
 		if (options == null || options == undefined) options = {};
-		
+
 		var mode = options.mode || '';
 
 		mode = (mode == '' && options.silent)? 'silent' : mode;
@@ -362,16 +362,16 @@
 				FileExt: '',
 				FileNameNoExt: '',
 				ProjectDir: '',
-				ProjectRel: ''				
+				ProjectRel: ''
 			}
 		}
-		
+
 		var command = replace( command || '', env );
 		var args = replace( args || [], env );
 		var options = replace( options || {}, env );
 		var matchs = matchs || [];
 		var cwd = options.cwd || '';
-		
+
 		if (options.save == true) {
 			var editor = atom.workspace.getActiveTextEditor();
 			if (editor) {
@@ -382,7 +382,7 @@
 				}
 			}
 		}
-		
+
 		// make a copy of args to avoid modify config
 		var argv = []
 		for (var i = 0; i < args.length; i++) {
@@ -397,14 +397,14 @@
 		if (mode != 'terminal') {
 			messagePlain(echo, 'echo');
 		}
-		
+
 		var XRegExp = require('xregexp');
 		var path = require('path');
-		
+
 		for (var i = 0; i < matchs.length; i++) {
 			matchs[i] = XRegExp.XRegExp(matchs[i]);
 		}
-		
+
 		function output(text, style) {
 			for (var i = 0; i < matchs.length; i++) {
 				var result = XRegExp.XRegExp.exec(text, matchs[i]);
@@ -430,12 +430,12 @@
 			messagePlain(text, style);
 			updateScroll();
 		}
-		
+
 		// sounds
 		var sounds = require('./sounds');
-		
+
 		// record time
-		var millisec = (new Date()).getTime();	
+		var millisec = (new Date()).getTime();
 		const spawn = require('child_process').spawn;
 		const terminal = require('./terminal');
 
@@ -444,13 +444,13 @@
 			//messagePlain("open new terminal to launch", "echo");
 			return;
 		}
-		
+
 		// Run the spawn, we pass argv to make a shallow copy of the array because spawn will modify it.
 		var proc = spawn( command, argv, options );
-		
+
 		var stdout_cache = '';
 		var stderr_cache = '';
-		
+
 		commands.childs[proc.pid] = proc;
 
 		// Update console panel on data
@@ -491,19 +491,19 @@
 				stderr_cache = '';
 			}
 		} );
-		
+
 		// Register code for error
 		proc.on('error', function(msg) {
 			output(msg, 'error');
 		});
-		
+
 		// Register code for termination
 		proc.on('close', function(code) {
 			var current = (new Date()).getTime();
 			var delta = (current - millisec) * 0.001;
 			var style = 'echo';
 			if (code == null || code == undefined) {
-				output('[Finished in ' + delta.toFixed(2) + ' seconds]', style);				
+				output('[Finished in ' + delta.toFixed(2) + ' seconds]', style);
 			}	else {
 				if (code == 0) {
 					output('[Finished in ' + delta.toFixed(2) + ' seconds]', style);
@@ -511,11 +511,11 @@
 					output('[Finished in ' + delta.toFixed(2) + ' seconds, with code ' + code.toString() + ']', style);
 				}
 			}
-			
+
 			if (proc.pid in commands.childs) {
 				delete commands.childs[proc.pid];
-			}			
-			
+			}
+
 			if (options.sound != undefined && options.sound != null && options.sound != '') {
 				sounds.play(options.sound);
 			}
@@ -530,22 +530,22 @@
 			return null;
 		if (editor.getPath == undefined || editor.getPath == null)
 			return null;
-			
+
 		var filepath = editor.getPath();
 
 		if (filepath == undefined || filepath == null) {
 			return null;
 		}
-		
+
 		var path = require('path');
 		var filename = path.basename(filepath);
 		var filedir = path.dirname(filepath);
-		
+
 		var info = path.parse(filepath);
 		var extname = info.ext;
 		var mainname = info.name;
 		var paths = atom.project.relativizePath(filepath);
-		if (extname == undefined || extname == null) extname = "";	
+		if (extname == undefined || extname == null) extname = "";
 		var selected = editor.getSelectedText() || "";
 		var position = editor.getCursorBufferPosition() || null;
 		var curcol = (position)? position.column : 0;
@@ -573,7 +573,7 @@
 			CurLineText: linetext,
 			CurWord: curword
 		};
-		
+
 		return env;
 	}
 
@@ -606,7 +606,7 @@
 
 	// Replace array string elements with variables
 	function replaceArray( input, vars ) {
-		var output = new Array(input.length);	
+		var output = new Array(input.length);
 		for ( var i = 0; i < input.length; i++ ) {
 			output[ i ] = replace( input[ i ], vars );
 		}
@@ -629,5 +629,3 @@
 	module.exports = commands;
 
 } )( window, atom, require, module );
-
-


### PR DESCRIPTION
On OSX, keyword "commands" in Atom config file seem to be reserved. Plugin was not working at all.

After renaming to something else, everything works as expected.